### PR TITLE
Fix bas_str and unnecessary transpose in jk.py

### DIFF
--- a/scf_11/SCF.py
+++ b/scf_11/SCF.py
@@ -23,8 +23,8 @@ def get_mints(bas):
 
     nbf = mints.nbf()
 
-    if (nbf > 100):
-        raise Exception("More than 100 basis functions!")
+    if (nbf > 200):
+        raise Exception("More than 200 basis functions!")
 
     return mints
 

--- a/scf_11/jk.py
+++ b/scf_11/jk.py
@@ -9,7 +9,7 @@ except SystemError:
 def JK_adv_setup(mints):
     # Building the auxiliary basis
     aux = psi4.core.BasisSet.build(params.mol, fitrole="JKFIT",
-                                   other="aug-cc-PVDZ")
+                                   other=params.bas_str)
 
     # Building the zero basis for the 2- and 3-center integrals
     zero_bas = psi4.core.BasisSet.zero_ao_basis_set()
@@ -39,8 +39,8 @@ def make_JK_adv(Pls, g, D, Cocc):
     J = np.einsum("pmn,p->mn", Pls, chi)
 
     # Building the Exchange matrix ( O(N^2*Naux*p) )
-    xi1 = np.einsum("qms,ps->qmp", Pls, Cocc.T)
-    xi2 = np.einsum("qnl,pl->qnp", Pls, Cocc.T)
+    xi1 = np.einsum("qms,sp->qmp", Pls, Cocc)
+    xi2 = np.einsum("qnl,lp->qnp", Pls, Cocc)
     K = np.einsum("qmp,qnp->mn", xi1, xi2)
 
     return J, K

--- a/scf_11/params.py
+++ b/scf_11/params.py
@@ -7,12 +7,13 @@ H 1 1.1 2 104
 """)
 mol.update_geometry()
 
-bas = psi4.core.BasisSet.build(mol, target="aug-cc-pVDZ")
+bas_str = "aug-cc-pVDZ"
+bas = psi4.core.BasisSet.build(mol, target=bas_str)
 
 e_conv = 1.e-6
 d_conv = 1.e-6
 nel = 5
 damp_value = 0.20
 damp_start = 5
-JK_mode = False
+JK_mode = False 
 DIIS_mode = False


### PR DESCRIPTION
Added a new variable in params.py, "bas_str" to hold a string for the basis set. This string is needed in jk.py. 

Also fixed an unnecessary transpose done within jk.py.